### PR TITLE
Fix getClosestParent() on IE11

### DIFF
--- a/branchingQuestion.js
+++ b/branchingQuestion.js
@@ -21,8 +21,8 @@ H5P.BranchingQuestion = (function () {
       if (!document.documentElement.contains(element)) {
         return null;
       }
-      if (!element.matches) {
-        element.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+      if (!Element.prototype.matches) {
+        Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
       }
 
       do {


### PR DESCRIPTION
When recursion was actually used to get the closest parent, the current element would not have the _matches_ function on IE11.